### PR TITLE
Update FrMedicationHistoryMedicationStatement.fsh

### DIFF
--- a/input/fsh/profiles/FrMedicationHistoryMedicationStatement.fsh
+++ b/input/fsh/profiles/FrMedicationHistoryMedicationStatement.fsh
@@ -39,7 +39,7 @@ Medication History MedicationStatement resource profile"""
 * medication[x].type = "Medication" (exactly)
 * medication[x].identifier ..0
 * medication[x].identifier ^requirements = "Identification du *médicament* uniquement par référence à une ressource *Medication* profilée *fr-medication*\\."
-* subject only Reference($FrCorePatient)
+* subject only Reference($FrCorePatientProfile)
 * subject MS
 * subject ^definition = "Le patient qui prend cette ligne de traitement médicamenteux."
 * subject ^comment = "Obligatoire dans la ressource FHIR *MedicationStatement* originelle, donc DOIT ABSOLUMENT être identique au patient identifé dans la ressource *Composition* du Bilan Médicamenteux. Cf. *Composition.subjet*\\."


### PR DESCRIPTION
File: /home/runner/work/hl7.fhir.fr.medication/hl7.fhir.fr.medication/igSource/input/fsh/profiles/FrMedicationHistoryMedicationStatement.fsh
  Line: 31
error No definition for the type "http://interopsante.org/fhir/StructureDefinition/FrPatient" could be found.

## Description des changements | Description of changes made

* [changement 1]
* [changement 2]
* ...

## Preview

https://interop-sante.github.io/hl7.fhir.fr.core/[ajouter_nom_de_la_branche]/ig

