### PR TITLE
Ajout héritage MPD

### DIFF
--- a/input/fsh/profiles/FrMedicationCompound.fsh
+++ b/input/fsh/profiles/FrMedicationCompound.fsh
@@ -1,5 +1,5 @@
-Profile: FrRedicationCompound
-Parent: Medication
+Profile: FrMedicationCompound
+Parent: MedicationEuMpd
 Id: fr-medication-compound
 Title: "FR Medication Compound"
 Description: "A complex medication composed of two to many simple medication. The simple medications component are described in as many ingredient.itemReference referencing a Medication resource profiled fr-medication-non-compound."

--- a/input/fsh/profiles/FrMedicationNonCompound.fsh
+++ b/input/fsh/profiles/FrMedicationNonCompound.fsh
@@ -1,5 +1,5 @@
 Profile: FRMedicationNonCompound
-Parent: Medication
+Parent: MedicationEuMpd
 Id: fr-medication-noncompound
 Title: "FR Medication Non Compound"
 Description: "Simple prescribed, dispensed, administered or used medication composed of one to many substances. If composed of many substance, the strengh SHALL be defined."

--- a/input/fsh/profiles/FrMedicationRequest.fsh
+++ b/input/fsh/profiles/FrMedicationRequest.fsh
@@ -1,5 +1,5 @@
 Profile: FRMedicationRequest
-Parent: MedicationRequest
+Parent: MedicationRequestEuMpd
 Id: fr-medicationrequest
 Title: "FR Medication Request"
 Description: "French medication request profile"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -20,6 +20,7 @@ parameters:
 
 dependencies:
   hl7.fhir.fr.core: 2.1.0
+  hl7.fhir.eu.mpd: 0.1.0-ballot
 
 pages:
     index.md: 


### PR DESCRIPTION
## Description des changements | Description of changes made

* Héritage de MedicationRequestEuMpd pour le profil FrMedicationRequest
* Héritage de MedicationEuMpd pour les profil FRMedicationNonCompound et FrMedicationCompound


Travaux en cours. Erreurs identifiées :
- Problématique Fr Core Patient / Europe Core Patient
- Manque authoredOn des lignes de prescription rendu obligatoire par l'europe

## Preview

https://interop-sante.github.io/hl7.fhir.fr.medication/[ajouter_nom_de_la_branche]/ig
